### PR TITLE
Revise how gcov is invoked

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,6 @@ runs:
          GAPInput
 
          # generate source coverage reports by running gcov
-         gcov -o . $(git ls-files :*.c :*.cc :*.cpp :*.C) || :
+         find . -type f -name '*.gcno' -exec gcov -pb {} +
 
         shell: bash


### PR DESCRIPTION
Instead of pointing gcov at source files, point it at .gcno files, which
contain the actual profiling info and which may not be found otherwise, as
they may be in `.libs` subdirectories. Also pass the `-pb` option to `gcov`,
like `codecov.sh` does.

Inspired by https://github.com/gap-system/gap/pull/4646

I'll test this now by pointing some gap-package at this commit. If it works, we can merge it and update the `v2` tag