### PR TITLE
Fix missing and invalid action options

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,7 @@ runs:
   using: "composite"
   steps:
       - name: "Process coverage data"
+        shell: bash
         run: |
          set -ex
          GAPROOT=${GAPROOT-$HOME/gap}
@@ -39,5 +40,6 @@ runs:
          GAPInput
 
       - name: "generate source coverage reports by running gcov"
+        shell: bash
         run: |
          find . -type f -name '*.gcno' -exec gcov -pb {} +

--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,5 @@
 name: 'Process coverage data'
 description: 'Process coverage data'
-env:
-  CHERE_INVOKING: 1
 
 runs:
   using: "composite"


### PR DESCRIPTION
This PR fixes some nonconformities with the `action.yml` schema (detailed [here](https://docs.github.com/en/actions/reference/workflows-and-actions/metadata-syntax#inputs)). Specifically, it adds the missing [runs.steps[*].shell](https://docs.github.com/en/actions/reference/workflows-and-actions/metadata-syntax#runsstepsshell) option, and removes the invalid `env` option.