### PR TITLE
Remove use of undocumented COVDIR env var

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ runs:
              Print("ERROR: could not load profiling package");
              FORCE_QUIT_GAP(1);
          fi;
-         d := Directory("${COVDIR-coverage}");
+         d := Directory("coverage");
          covs := [];
          files := DirectoryContents(d);
          if files = fail then


### PR DESCRIPTION
See also https://github.com/gap-actions/run-pkg-tests/pull/44

No GAP package seems to use this in their GH workflows.