### PR TITLE
Cleanup, ::error:: usage, README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ package.
 By default it processes the coverage data gathered during the action
 [gap-actions/run-test-for-packages](https://github.com/gap-actions/run-pkg-tests).
 
+When using `codecov/codecov-action`, we recommend setting the (optional) input
+`fail_ci_if_error` to `true`, as otherwise uploads may silently fail. Moreover, it
+might be necessary to [add an upload token for Codecov](https://docs.codecov.com/docs/codecov-tokens).
+
+
 ### What's new in v3
 
 This action now requires `gap-actions/setup-gap@v3`.
@@ -37,10 +42,18 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: gap-actions/setup-gap@v3
-      - uses: gap-actions/build-pkg@v1
-      - uses: gap-actions/run-pkg-tests@v2
+      - uses: gap-actions/build-pkg@v2
+      - uses: gap-actions/run-pkg-tests@v4
       - uses: gap-actions/process-coverage@v3
       - uses: codecov/codecov-action@v5
+```
+
+The recommended configuration for `codecov/codecov-action` is as follows:
+```yaml
+      - uses: codecov/codecov-action@v5
+        with:
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
 ```
 
 ## Contact

--- a/action.yml
+++ b/action.yml
@@ -4,58 +4,58 @@ description: 'Process coverage data'
 runs:
   using: "composite"
   steps:
-      - name: "Build io and profiling packages if necessary"
-        shell: bash
-        run: |
-         # the following somewhat awkward `cd` invocation ensures
-         # compatibility with both GAP <= 4.11 (with package dir names like
-         # `pkg/io-1.2.3`) and GAP >= 4.12 (where it is `pkg/io`)
-         cd $GAPROOT/pkg/io || cd $GAPROOT/pkg/io-*
-         if [[ ! -f config.status ]] ; then
-           ./configure --with-gaproot=$GAPROOT
-         fi
-         make -j$(nproc)
+    - name: "Build io and profiling packages if necessary"
+      shell: bash
+      run: |
+        # the following somewhat awkward `cd` invocation ensures
+        # compatibility with both GAP <= 4.11 (with package dir names like
+        # `pkg/io-1.2.3`) and GAP >= 4.12 (where it is `pkg/io`)
+        cd $GAPROOT/pkg/io || cd $GAPROOT/pkg/io-*
+        if [[ ! -f config.status ]] ; then
+          ./configure --with-gaproot=$GAPROOT
+        fi
+        make -j$(nproc)
 
-         cd $GAPROOT/pkg/profiling || cd $GAPROOT/pkg/profiling-*
-         if [[ ! -f Makefile ]] ; then
-           if [[ -f configure.ac ]] ; then
-             ./configure --with-gaproot=$GAPROOT
-           else
-             ./configure $GAPROOT
-           fi
-         fi
-         make -j$(nproc)
+        cd $GAPROOT/pkg/profiling || cd $GAPROOT/pkg/profiling-*
+        if [[ ! -f Makefile ]] ; then
+          if [[ -f configure.ac ]] ; then
+            ./configure --with-gaproot=$GAPROOT
+          else
+            ./configure $GAPROOT
+          fi
+        fi
+        make -j$(nproc)
 
-      - name: "Process coverage data"
-        shell: bash
-        run: |
-         # generate library coverage reports
-         $GAP -q <<GAPInput
-         if LoadPackage("profiling") <> true then
-             Print("ERROR: could not load profiling package");
-             FORCE_QUIT_GAP(1);
-         fi;
-         d := Directory("coverage");
-         covs := [];
-         files := DirectoryContents(d);
-         if files = fail then
-            Print("no coverage data found\n");
-            QUIT_GAP(0);
-         fi;
-         for f in files do
-             if f in [".", ".."] then continue; fi;
-             Add(covs, Filename(d, f));
-         od;
-         Print("Merging coverage results from ", covs, "\n");
-         r := MergeLineByLineProfiles(covs);;
-         # filtered out unwanted other packages to avoid bad coverage interaction
-         r.line_info := Filtered(r.line_info, x -> not StartsWith( x[1], "$GAPROOT/" ) );;
-         Print("Outputting JSON\n");
-         OutputJsonCoverage(r, "gap-coverage.json");
-         QUIT_GAP(0);
-         GAPInput
+    - name: "Process coverage data"
+      shell: bash
+      run: |
+        # generate library coverage reports
+        $GAP -q <<GAPInput
+        if LoadPackage("profiling") <> true then
+          Exec("echo \"::error::Could not load profiling package\"");
+          FORCE_QUIT_GAP(1);
+        fi;
+        d := Directory("coverage");
+        covs := [];
+        files := DirectoryContents(d);
+        if files = fail then
+          Exec("echo \"::warning::No coverage data found\"");
+          QUIT_GAP(0);
+        fi;
+        for f in files do
+          if f in [".", ".."] then continue; fi;
+          Add(covs, Filename(d, f));
+        od;
+        Print("Merging coverage results from ", covs, "\n");
+        r := MergeLineByLineProfiles(covs);;
+        # filtered out unwanted other packages to avoid bad coverage interaction
+        r.line_info := Filtered(r.line_info, x -> not StartsWith( x[1], "$GAPROOT/" ) );;
+        Print("Outputting JSON\n");
+        OutputJsonCoverage(r, "gap-coverage.json");
+        QUIT_GAP(0);
+        GAPInput
 
-      - name: "generate source coverage reports by running gcov"
-        shell: bash
-        run: |
-         find . -type f -name '*.gcno' -exec gcov -pb {} +
+    - name: "generate source coverage reports by running gcov"
+      shell: bash
+      run: |
+       find . -type f -name '*.gcno' -exec gcov -pb {} +


### PR DESCRIPTION
- Update README with recommendations regarding `codecov-action` (see #24).
- Update action versions in README.
- Replace GAP `Error` by `Exec("echo \"::error:: [...] \""); FORCE_QUIT_GAP(1);` to make the errors more visible in GitHub Action logs.
- Made indendation consistent (2 spaces per level).